### PR TITLE
Missing metrics endpoint path in metrics exporter factory

### DIFF
--- a/Otlp/MetricExporterFactory.php
+++ b/Otlp/MetricExporterFactory.php
@@ -55,7 +55,7 @@ class MetricExporterFactory implements MetricExporterFactoryInterface
             case KnownValues::VALUE_HTTP_PROTOBUF:
             case KnownValues::VALUE_HTTP_JSON:
                 return $factory->create(
-                    $endpoint,
+                    $endpoint . OtlpUtil::method(Signals::METRICS),
                     Protocols::contentType($protocol),
                     $headers
                 );


### PR DESCRIPTION
The path is correctly added in SpanExporterFactory, but not in MetricExporterFactory